### PR TITLE
Improve latency by disabling TCP delay.

### DIFF
--- a/joueur/src/unix_connection.hpp
+++ b/joueur/src/unix_connection.hpp
@@ -73,6 +73,11 @@ public:
                close(sock_);
                sock_ = -1;
             }
+            else
+            {
+               int turn_on = 1;
+               setsockopt(sock_, IPPROTO_TCP, TCP_NODELAY, &turn_on, sizeof(turn_on));
+            }
          }
       }
       // if sock_ is invalid some sort of error occured

--- a/joueur/src/unix_connection.hpp
+++ b/joueur/src/unix_connection.hpp
@@ -6,6 +6,7 @@
 #include <netdb.h>
 #include <unistd.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 
 #include <string>
 #include <array>


### PR DESCRIPTION
Specifically, setting the `TCP_NODELAY` option on the created socket. 